### PR TITLE
Put webpack dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,16 @@
   "version": "1.0.0",
   "description": "",
   "main": "webpack.config.js",
-  "dependencies": {},
+  "dependencies": {
+    "css-loader": "^0.25.0",
+    "elm-webpack-loader": "^3.0.6",
+    "file-loader": "^0.9.0",
+    "style-loader": "^0.13.1",
+    "url-loader": "^0.5.7",
+    "webpack": "^1.13.2",
+    "webpack-dev-middleware": "^1.6.1",
+    "webpack-dev-server": "^1.15.1"
+  },
   "devDependencies": {},
   "scripts": {
     "build": "webpack",


### PR DESCRIPTION
The webpack dependencies as required and listed here:
http://www.elm-tutorial.org/en/04-starting/03-webpack.html

weren't saved to the package.json for some reason. This rectifies that.
