### PR TITLE
Submitting new proposal form

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -229,18 +229,6 @@ viewBody model =
 
 formView : Model -> Html Msg
 formView model =
-  let
-    errorFor field =
-      case field.liveError of
-        Just error ->
-          div [ class "error" ] [ text (toString error) ]
-
-        Nothing ->
-          text ""
-
-    title = Form.getFieldAsString "title" model.form
-    body = Form.getFieldAsString "body" model.form
-  in
     grid []
       [ cell [ size All 12 ] [ titleField model ]
       , cell [ size All 12 ] [ bodyField model ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -122,6 +122,7 @@ type alias Proposal =
 
 type Msg
   = ApiMsg Api.Msg
+  | NavigateToPath String
   | FormMsg Form.Msg
   | NewProposalFormMsg
   | NoOp
@@ -147,6 +148,11 @@ update msg model =
 
         Api.ProposalCreationFailed httpError ->
           ({ model | error = Just <| toString httpError }, Cmd.none)
+
+    NavigateToPath path ->
+      ( model,
+        Navigation.newUrl <| Hop.outputFromPath hopConfig path
+      )
 
     FormMsg formMsg ->
       case ( formMsg, Form.getOutput model.form ) of
@@ -209,7 +215,8 @@ viewBody model =
             text <| "Hello, " ++ ( .name model.me )
             ,
             h3 []
-              [ a [ href "/new-proposal" ] [ text "Create a proposal" ] ]
+              [ a [ onClick <| NavigateToPath "/new-proposal" ]
+                  [ text "Create a proposal 3" ] ]
           ]
 
     NewProposalRoute ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -301,7 +301,7 @@ bodyField model =
         model.mdl
         ([ Textfield.label "Body"
          , Textfield.floatingLabel
-         , Textfield.text'
+         , Textfield.textarea
          , Textfield.value <| Maybe.withDefault "" body.value
          , Textfield.onInput <| FormMsg << (Form.Field.Text >> Form.Input body.path)
          , Textfield.onFocus <| FormMsg <| Form.Focus body.path

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -260,7 +260,7 @@ titleField model =
           []
   in
       Textfield.render Mdl
-        [ 1, 0 ]
+        [ 0, 0 ]
         model.mdl
         ([ Textfield.label "Title"
          , Textfield.floatingLabel
@@ -297,7 +297,7 @@ bodyField model =
           []
   in
       Textfield.render Mdl
-        [ 1, 0 ]
+        [ 0, 1 ]
         model.mdl
         ([ Textfield.label "Body"
          , Textfield.floatingLabel
@@ -314,7 +314,7 @@ bodyField model =
 submitButton : Model -> Html Msg
 submitButton model =
   Button.render Mdl
-    [ 1, 1 ]
+    [ 1 ]
     model.mdl
     [ Button.raised
     , Button.ripple

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -216,7 +216,7 @@ viewBody model =
             ,
             h3 []
               [ a [ onClick <| NavigateToPath "/new-proposal" ]
-                  [ text "Create a proposal 3" ] ]
+                  [ text "Create a proposal" ] ]
           ]
 
     NewProposalRoute ->


### PR DESCRIPTION
Form now renders and submits, but the authorization header is missing the access token.

This is due to how the new proposal route is being accessed:

```
[ a [ href "/new-proposal" ] [ text "Create a proposal" ] ]
```

It's being treated as an actual page, and so the model gets reset when the page loads. The access token is currently stored in the model, so it's lost as well. 

The token should really be stored in local storage, going to add an issue for this. 

But the routing here should be internal as well, rather than reloading the whole thing, and this will also ensure the access token is still present during form submittal, while it's not in local storage. 
- [x] Make routing to new proposal form internal (single page)

Closes #4 
