### PR TITLE
Process created proposal

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -76,7 +76,20 @@ urlParser =
 
 urlUpdate : ( Route, Address ) -> Model -> ( Model, Cmd Msg )
 urlUpdate ( route, address ) model =
-  ( { model | route = route, address = address }, Cmd.none )
+  let
+    model1 = { model | route = route, address = address }
+    _ = Debug.log "urlUpdate" ( route, address )
+  in
+    case route of
+      ProposalRoute id ->
+        case Dict.get id model.proposals of
+          Nothing ->
+            -- Todo: Get proposal from server
+            ( model1, Cmd.none )
+          Just _ ->
+            ( model1, Cmd.none )
+      _ ->
+        ( model1, Cmd.none )
 
 
 checkForAuthCode : Address -> Cmd Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -38,6 +38,7 @@ import Api
 type Route
   = Home
   | NewProposalRoute
+  | ProposalRoute String
   | FacebookRedirect
   | NotFoundRoute
 
@@ -47,6 +48,7 @@ routes =
   UrlParser.oneOf
     [ UrlParser.format Home (UrlParser.s "")
     , UrlParser.format NewProposalRoute (UrlParser.s "new-proposal")
+    , UrlParser.format ProposalRoute (UrlParser.s "proposals" </> UrlParser.string)
     , UrlParser.format FacebookRedirect (UrlParser.s "facebook_redirect")
     ]
 
@@ -235,6 +237,12 @@ viewBody model =
           ,
 
           formView model
+        ]
+
+    ProposalRoute id ->
+      div []
+        [ h2 [] [ text "Proposal" ]
+        , p [] [ text "Id: ", text id ]
         ]
 
     NotFoundRoute ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -129,11 +129,11 @@ type alias Model =
   }
 
 
-initialModel : Route -> Address -> Model
-initialModel route address = 
+initialModel : String -> Route -> Address -> Model
+initialModel accessToken route address =
   { route = route
   , address = address
-  , accessToken = ""
+  , accessToken = accessToken
   , error = Nothing
   , me = { name = "" }
   , form = Form.initial [] validate
@@ -400,11 +400,11 @@ viewProposal model id =
 -- APP
 
 
-init : flags -> ( Route, Address ) -> ( Model, Cmd Msg )
+init : Flags -> ( Route, Address ) -> ( Model, Cmd Msg )
 init flags ( route, address ) =
-  let _ = Debug.log "flags" flags
-  in
-    ( initialModel route address, checkForAuthCode address)
+  ( initialModel (Maybe.withDefault "" flags.accessToken) route address
+  , checkForAuthCode address
+  )
 
 
 type alias Flags =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -143,7 +143,10 @@ update msg model =
           ({ model | me = me}, Navigation.newUrl "/")
 
         Api.ProposalCreated id proposal ->
-          (model, Navigation.newUrl "/")
+          ( model
+          , Navigation.newUrl
+              <| Hop.output hopConfig { path = ["proposals", id], query = Dict.empty }
+          )
 
         Api.ProposalCreationFailed httpError ->
           ({ model | error = Just <| toString httpError }, Cmd.none)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -400,14 +400,19 @@ viewProposal model id =
 -- APP
 
 
-init : ( Route, Address ) -> ( Model, Cmd Msg )
-init ( route, address ) =
-  ( initialModel route address, checkForAuthCode address)
+init : flags -> ( Route, Address ) -> ( Model, Cmd Msg )
+init flags ( route, address ) =
+  let _ = Debug.log "flags" flags
+  in
+    ( initialModel route address, checkForAuthCode address)
 
+
+type alias Flags =
+  { accessToken : Maybe String }
  
-main : Program Never
+main : Program Flags
 main =
-  Navigation.program urlParser
+  Navigation.programWithFlags urlParser
     { init = init
     , update = update
     , urlUpdate = urlUpdate

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -406,9 +406,11 @@ type alias Flags =
 
 init : Flags -> ( Route, Address ) -> ( Model, Cmd Msg )
 init flags ( route, address ) =
-  ( initialModel (Maybe.withDefault "" flags.accessToken) route address
-  , checkForAuthCode address
-  )
+  let
+    model0 = initialModel (Maybe.withDefault "" flags.accessToken) route address
+    ( model1, cmd1 ) = urlUpdate ( route, address ) model0
+  in
+    ( model1, Cmd.batch [cmd1, checkForAuthCode address] )
 
 
 main : Program Flags

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -84,8 +84,9 @@ urlUpdate ( route, address ) model =
       ProposalRoute id ->
         case Dict.get id model.proposals of
           Nothing ->
-            -- Todo: Get proposal from server
-            ( model1, Cmd.none )
+            ( model1
+            , Api.getProposalCmd id model.accessToken ApiMsg
+            )
           Just _ ->
             ( model1, Cmd.none )
       _ ->
@@ -167,12 +168,20 @@ update msg model =
           ({ model | me = me}, Navigation.newUrl "/")
 
         Api.ProposalCreated id proposal ->
-          ( { model | proposals = Dict.insert id proposal model.proposals }
+          ( model -- { model | proposals = Dict.insert id proposal model.proposals }
           , Navigation.newUrl
               <| Hop.output hopConfig { path = ["proposals", id], query = Dict.empty }
           )
 
         Api.ProposalCreationFailed httpError ->
+          ({ model | error = Just <| toString httpError }, Cmd.none)
+
+        Api.GotProposal id proposal ->
+          ( { model | proposals = Dict.insert id proposal model.proposals }
+          , Cmd.none
+          )
+
+        Api.GettingProposalFailed httpError ->
           ({ model | error = Just <| toString httpError }, Cmd.none)
 
     NavigateToPath path ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -21,7 +21,7 @@ import Form.Input
 import Form.Error
 import Form.Validate exposing (Validation, form1, form2, get, string)
 
-import Dict
+import Dict exposing (Dict)
 import String
 
 import Navigation
@@ -102,6 +102,7 @@ type alias Model =
   , me : Api.Me
   , form : Form () Proposal
   , mdl : Material.Model
+  , proposals : Dict String Proposal
   }
 
 
@@ -114,6 +115,7 @@ initialModel route address =
   , me = { name = "" }
   , form = Form.initial [] validate
   , mdl = Material.model
+  , proposals = Dict.empty
   }
 
 
@@ -150,7 +152,7 @@ update msg model =
           ({ model | me = me}, Navigation.newUrl "/")
 
         Api.ProposalCreated id proposal ->
-          ( model
+          ( { model | proposals = Dict.insert id proposal model.proposals }
           , Navigation.newUrl
               <| Hop.output hopConfig { path = ["proposals", id], query = Dict.empty }
           )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -168,7 +168,7 @@ update msg model =
           ({ model | me = me}, Navigation.newUrl "/")
 
         Api.ProposalCreated id proposal ->
-          ( model -- { model | proposals = Dict.insert id proposal model.proposals }
+          ( { model | proposals = Dict.insert id proposal model.proposals }
           , Navigation.newUrl
               <| Hop.output hopConfig { path = ["proposals", id], query = Dict.empty }
           )

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -242,7 +242,7 @@ viewBody model =
     ProposalRoute id ->
       div []
         [ h2 [] [ text "Proposal" ]
-        , p [] [ text "Id: ", text id ]
+        , viewProposal model id
         ]
 
     NotFoundRoute ->
@@ -349,6 +349,18 @@ submitButton model =
     , Button.onClick <| FormMsg <| Form.Submit
     ]
     [ text "Submit" ]
+
+
+viewProposal : Model -> String -> Html Msg
+viewProposal model id =
+  case Dict.get id model.proposals of
+    Nothing ->
+      div [] [text "Unknown proposal id: ", text id]
+    Just proposal ->
+      div []
+        [ div [] [text "Titel: ", text proposal.title]
+        , div [] [text "Body: ", text proposal.body]
+        ]
 
 
 -- APP

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,3 +1,5 @@
+port module Main exposing (main)
+
 import Html exposing (..)
 import Html.App as App
 import Html.Events exposing (..)
@@ -107,6 +109,11 @@ checkForAuthCode address =
 
 
 
+-- Port for storage of accessToken
+
+port storeAccessToken : String -> Cmd msg
+
+
 -- MODEL
 
 
@@ -159,7 +166,12 @@ update msg model =
     ApiMsg apiMsg ->
       case apiMsg of
         Api.GotAccessToken accessToken ->
-          ({ model | accessToken = accessToken }, Api.getMeCmd accessToken ApiMsg )
+          ( { model | accessToken = accessToken }
+          , Cmd.batch
+              [ storeAccessToken accessToken
+              , Api.getMeCmd accessToken ApiMsg
+              ]
+          )
 
         Api.AuthFailed httpError ->
           ({ model | error = Just <| toString httpError }, Cmd.none)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -400,6 +400,10 @@ viewProposal model id =
 -- APP
 
 
+type alias Flags =
+  { accessToken : Maybe String }
+
+
 init : Flags -> ( Route, Address ) -> ( Model, Cmd Msg )
 init flags ( route, address ) =
   ( initialModel (Maybe.withDefault "" flags.accessToken) route address
@@ -407,9 +411,6 @@ init flags ( route, address ) =
   )
 
 
-type alias Flags =
-  { accessToken : Maybe String }
- 
 main : Program Flags
 main =
   Navigation.programWithFlags urlParser

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -142,7 +142,7 @@ update msg model =
         Api.GotMe me ->
           ({ model | me = me}, Navigation.newUrl "/")
 
-        Api.ProposalCreated proposal ->
+        Api.ProposalCreated id proposal ->
           (model, Navigation.newUrl "/")
 
         Api.ProposalCreationFailed httpError ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -107,7 +107,14 @@ type alias Model =
 
 initialModel : Route -> Address -> Model
 initialModel route address = 
-  Model route address "" Nothing { name = "" } (Form.initial [] validate) Material.model
+  { route = route
+  , address = address
+  , accessToken = ""
+  , error = Nothing
+  , me = { name = "" }
+  , form = Form.initial [] validate
+  , mdl = Material.model
+  }
 
 
 type alias Proposal =

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ var mountNode = document.getElementById('main');
 // The third value on embed are the initial values for incomming ports into Elm
 var app = Elm.Main.embed(mountNode);
 
+app.ports.storeAccessToken.subscribe (function (accessToken) {
+  sessionStorage.setItem ('accessToken', accessToken);
+});
+
 // TODO: Figure out how popup that only gets the authorization code
 // so we can post it to our backend and continue oauth from there
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,12 @@ require('./index.html');
 var Elm = require('./Main.elm');
 var mountNode = document.getElementById('main');
 
+var programFlags = {
+  accessToken: sessionStorage.getItem ('accessToken')
+};
+
 // The third value on embed are the initial values for incomming ports into Elm
-var app = Elm.Main.embed(mountNode);
+var app = Elm.Main.embed(mountNode, programFlags);
 
 app.ports.storeAccessToken.subscribe (function (accessToken) {
   sessionStorage.setItem ('accessToken', accessToken);


### PR DESCRIPTION
Implements #14: Project details view

Situation: Client has posted new proposal to server, which responded with the same proposal content and a new id.
- [x] decode id from response
- [x] save the proposal in the model using a dict id->content
- [x] change route to `/proposals/:id`
- [x] define this route for Hop
- [x] view a proposal
- [x] fetch uncached proposals from server (untested, results in server error)
