### PR TITLE
WIP listing proposals

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -240,9 +240,14 @@ update msg model =
           ({ model | error = Just <| toString httpError }, Cmd.none)
 
         Api.GotProposalList proposalList ->
-          (
-            let _ = Debug.log "proposalList" proposalList
-            in model -- { model | proposals = proposalList }
+          ( let
+              updatedProposals =
+                Dict.fromList <|
+                  List.map
+                    (\proposal -> (proposal.id, proposal))
+                    proposalList
+            in
+              { model | proposals = updatedProposals }
           , Cmd.none
           )
 
@@ -312,12 +317,11 @@ viewBody model =
             [ a [ href Api.facebookAuthUrl ] [ text "Login with Facebook" ] ]
         else
           div []
-            [
-              text <| "Hello, " ++ ( .name model.me )
-              ,
-              h3 []
+            [ text <| "Hello, " ++ ( .name model.me )
+            , h3 []
                 [ a [ onClick <| NavigateToPath "/new-proposal" ]
                     [ text "Create a proposal" ] ]
+            , h3 [] [ viewProposalList model ]
             ]
 
       NewProposalRoute ->
@@ -462,6 +466,19 @@ viewParticipantName model id =
       div [] [text "Unknown (or uncached) author id: ", text id]
     Just participant ->
       text participant.attr.name
+
+
+viewProposalList : Model -> Html Msg
+viewProposalList model =
+  ul [] <|
+    List.map
+      viewProposalListEntry
+      (Dict.values model.proposals)
+
+
+viewProposalListEntry : Proposal -> Html Msg
+viewProposalListEntry proposal =
+  li [] [ text proposal.attr.title ]
 
 
 -- APP

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -321,7 +321,8 @@ viewBody model =
             , h3 []
                 [ a [ onClick <| NavigateToPath "/new-proposal" ]
                     [ text "Create a proposal" ] ]
-            , h3 [] [ viewProposalList model ]
+            , h3 [] [ text "Existing Proposals" ]
+            , div [] [ viewProposalList model ]
             ]
 
       NewProposalRoute ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -479,7 +479,11 @@ viewProposalList model =
 
 viewProposalListEntry : Proposal -> Html Msg
 viewProposalListEntry proposal =
-  li [] [ text proposal.attr.title ]
+  li []
+    [ a
+        [onClick <| NavigateToPath <| "proposals/" ++ proposal.id]
+        [text proposal.attr.title]
+    ]
 
 
 -- APP


### PR DESCRIPTION
Closes #16 

@ThomasWeiser I need a hand :)

I'm going towards a `ProposalList` type that's a `List Proposal` or a `List (Proposal, Participant)`. This will change how `proposals` is set in the model, and I'm also stuck with the following compiler error:

```
ERROR in ./src/Main.elm
Module build failed: Error: Compiler process exited with error Compilation failed
-- TYPE MISMATCH ------------------------------------------------- ./src/Api.elm

The right argument of (|>) is causing a type mismatch.

236|   getProposalList id accessToken
237|>    |> Task.perform GettingProposalListFailed (uncurry GotProposalList)

(|>) is expecting the right argument to be a:

    Task Http.Error (List ( Proposal, Participant )) -> a

But the right argument is:

    Task Http.Error ( ProposalList, a ) -> Cmd Msg

Hint: I always figure out the type of the left argument first and if it is
acceptable on its own, I assume it is "correct" in subsequent checks. So the
problem may actually be in how the left and right arguments interact.

-- TYPE MISMATCH ------------------------------------------------- ./src/Api.elm

The argument to function `uncurry` is causing a mismatch.

237|                                                uncurry GotProposalList)
                                                            ^^^^^^^^^^^^^^^
Function `uncurry` is expecting the argument to be:

    ProposalList -> a -> b

But it is:

    ProposalList -> Msg
```

Maybe we can pair on this? Let me know when you got some time