### PR TITLE
Refactor resource types

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -16,6 +16,7 @@
         "evancz/elm-http": "3.0.1 <= v < 4.0.0",
         "evancz/url-parser": "1.0.0 <= v < 2.0.0",
         "noahzgordon/elm-jsonapi": "2.0.2 <= v < 3.0.0",
+        "noahzgordon/elm-jsonapi-http": "1.0.2 <= v < 2.0.0",
         "sporto/erl": "10.0.1 <= v < 11.0.0",
         "sporto/hop": "6.0.0 <= v < 7.0.0"
     },

--- a/elm-package.json
+++ b/elm-package.json
@@ -16,7 +16,6 @@
         "evancz/elm-http": "3.0.1 <= v < 4.0.0",
         "evancz/url-parser": "1.0.0 <= v < 2.0.0",
         "noahzgordon/elm-jsonapi": "2.0.2 <= v < 3.0.0",
-        "noahzgordon/elm-jsonapi-http": "1.0.2 <= v < 2.0.0",
         "sporto/erl": "10.0.1 <= v < 11.0.0",
         "sporto/hop": "6.0.0 <= v < 7.0.0"
     },

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -143,8 +143,7 @@ authenticate authCode wrapMsg =
     ("{\"auth_code\": \"" ++ authCode ++ "\"}")
         |> Api.Util.requestPost tokenEndpoint
         |> JsonApi.Extra.withHeader "Content-Type" "application/json"
-        |> Http.send Http.defaultSettings
-        |> Http.fromJson decodeToken
+        |> Api.Util.sendDefJson decodeToken
         |> Task.perform AuthFailed GotAccessToken
         |> Cmd.map wrapMsg
 

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -17,7 +17,6 @@ import JsonApi
 import JsonApi.Decode
 import JsonApi.Resources
 import JsonApi.Documents
-import JsonApi.Http
 import Types exposing (..)
 
 

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -2,7 +2,6 @@ module Api
     exposing
         ( facebookAuthUrl
         , Msg(..)
-        , Me
         , authenticateCmd
         , getMeCmd
         , createProposalCmd
@@ -14,6 +13,7 @@ import Task exposing (Task)
 import Json.Decode as Decode
 import Json.Decode exposing (Decoder)
 import Json.Encode as Encode
+import Types exposing (..)
 
 
 type Msg
@@ -24,35 +24,6 @@ type Msg
     | GotProposal Proposal Participant
     | GettingProposalFailed Http.Error
     | GotMe Me
-
-
-type alias Me =
-    { name : String
-    }
-
-
-type alias ProposalAttr =
-    { title : String
-    , body : String
-    }
-
-
-type alias Proposal =
-    { id : String
-    , author : String
-    , attr : ProposalAttr
-    }
-
-
-type alias ParticipantAttr =
-    { name : String
-    }
-
-
-type alias Participant =
-    { id : String
-    , attr : ParticipantAttr
-    }
 
 
 

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -127,20 +127,11 @@ decodeParticipantAttributes =
 
 encodeProposalInput : ProposalInput -> String
 encodeProposalInput proposalInput =
-    Encode.object
-        [ ( "data"
-          , Encode.object
-                [ ( "type", Encode.string "proposal" )
-                , ( "attributes"
-                  , Encode.object
-                        [ ( "title", Encode.string proposalInput.title )
-                        , ( "body", Encode.string proposalInput.body )
-                        ]
-                  )
-                ]
-          )
-        ]
-        |> Encode.encode 0
+    JsonApi.Extra.encodeDocument "proposal" <|
+        Encode.object
+            [ ( "title", Encode.string proposalInput.title )
+            , ( "body", Encode.string proposalInput.body )
+            ]
 
 
 

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -17,8 +17,8 @@ import JsonApi
 import JsonApi.Resources
 import JsonApi.Documents
 import JsonApi.Extra
-import Types exposing (..)
 import Api.Util exposing ((:>))
+import Types exposing (..)
 
 
 type Msg
@@ -149,9 +149,7 @@ encodeProposalInput proposalInput =
 
 authenticate : String -> (Msg -> a) -> Cmd a
 authenticate authCode wrapMsg =
-    "{\"auth_code\": \""
-        ++ authCode
-        ++ "\"}"
+    ("{\"auth_code\": \"" ++ authCode ++ "\"}")
         |> Api.Util.requestPost tokenEndpoint
         |> JsonApi.Extra.withHeader "Content-Type" "application/json"
         |> Http.send Http.defaultSettings

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -13,6 +13,11 @@ import Task exposing (Task)
 import Json.Decode as Decode
 import Json.Decode exposing (Decoder)
 import Json.Encode as Encode
+import JsonApi
+import JsonApi.Decode
+import JsonApi.Resources
+import JsonApi.Documents
+import JsonApi.Http
 import Types exposing (..)
 
 

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -125,7 +125,7 @@ decodeParticipantAttributes =
     Decode.at [ "name" ] Decode.string
 
 
-encodeProposalInput : ProposalInput -> String
+encodeProposalInput : NewProposal -> String
 encodeProposalInput proposalInput =
     JsonApi.Extra.encodeDocument "proposal" <|
         Encode.object
@@ -158,7 +158,7 @@ getMe accessToken wrapMsg =
         |> Cmd.map wrapMsg
 
 
-createProposal : ProposalInput -> String -> (Msg -> a) -> Cmd a
+createProposal : NewProposal -> String -> (Msg -> a) -> Cmd a
 createProposal proposalInput accessToken wrapMsg =
     encodeProposalInput proposalInput
         |> Api.Util.requestPost newProposalEndpoint

--- a/src/Api/Util.elm
+++ b/src/Api/Util.elm
@@ -1,0 +1,47 @@
+module Api.Util exposing (..)
+
+import Task exposing (Task)
+import Http
+import JsonApi
+import JsonApi.Extra
+
+
+{-| Infix notation for Result.andThen. Makes andThen-chains look nicer.
+-}
+infixl 0 :>
+(:>) : Result x a -> (a -> Result x b) -> Result x b
+(:>) =
+    Result.andThen
+
+
+withAccessToken : String -> Http.Request -> Http.Request
+withAccessToken accessToken =
+    JsonApi.Extra.httpWithHeader "Authorization" ("Bearer " ++ accessToken)
+
+
+requestGet : String -> String -> Http.Request
+requestGet accessToken url =
+    withAccessToken accessToken
+        { verb = "GET"
+        , headers = []
+        , url = url
+        , body = Http.empty
+        }
+
+
+requestPost : String -> String -> String -> Http.Request
+requestPost accessToken url body =
+    withAccessToken accessToken
+        { verb = "POST"
+        , headers = []
+        , url = url
+        , body = Http.string body
+        }
+
+
+sendJsonApi :
+    (JsonApi.Document -> Result String a)
+    -> Http.Request
+    -> Task Http.Error a
+sendJsonApi assembleResponse request =
+    JsonApi.Extra.httpSendJsonApi assembleResponse Http.defaultSettings request

--- a/src/Api/Util.elm
+++ b/src/Api/Util.elm
@@ -1,6 +1,7 @@
 module Api.Util exposing (..)
 
 import Task exposing (Task)
+import Json.Decode as Decode
 import Http
 import JsonApi
 import JsonApi.Extra
@@ -52,3 +53,16 @@ sendDefJsonApi :
     -> Task Http.Error a
 sendDefJsonApi assembleResponse request =
     JsonApi.Extra.sendJsonApi assembleResponse Http.defaultSettings request
+
+
+{-| Send a Http request with default settings
+and decode the response from JSON
+-}
+sendDefJson :
+    Decode.Decoder a
+    -> Http.Request
+    -> Task Http.Error a
+sendDefJson decodeResponse request =
+    request
+        |> Http.send Http.defaultSettings
+        |> Http.fromJson decodeResponse

--- a/src/Api/Util.elm
+++ b/src/Api/Util.elm
@@ -18,39 +18,37 @@ infixl 0 :>
 -}
 withAccessToken : String -> Http.Request -> Http.Request
 withAccessToken accessToken =
-    JsonApi.Extra.httpWithHeader "Authorization" ("Bearer " ++ accessToken)
+    JsonApi.Extra.withHeader "Authorization" ("Bearer " ++ accessToken)
 
 
-{-| Build a GET request with an accessToken
+{-| Build a GET request
 -}
-requestGet : String -> String -> Http.Request
-requestGet accessToken url =
-    withAccessToken accessToken
-        { verb = "GET"
-        , headers = []
-        , url = url
-        , body = Http.empty
-        }
+requestGet : String -> Http.Request
+requestGet url =
+    { verb = "GET"
+    , headers = []
+    , url = url
+    , body = Http.empty
+    }
 
 
-{-| Build a POST request with an accessToken
+{-| Build a POST request
 -}
-requestPost : String -> String -> String -> Http.Request
-requestPost accessToken url body =
-    withAccessToken accessToken
-        { verb = "POST"
-        , headers = []
-        , url = url
-        , body = Http.string body
-        }
+requestPost : String -> String -> Http.Request
+requestPost url body =
+    { verb = "POST"
+    , headers = []
+    , url = url
+    , body = Http.string body
+    }
 
 
 {-| Send a Http request with default settings
 and decode the response from a JSON API document
 -}
-sendJsonApi :
+sendDefJsonApi :
     (JsonApi.Document -> Result String a)
     -> Http.Request
     -> Task Http.Error a
-sendJsonApi assembleResponse request =
-    JsonApi.Extra.httpSendJsonApi assembleResponse Http.defaultSettings request
+sendDefJsonApi assembleResponse request =
+    JsonApi.Extra.sendJsonApi assembleResponse Http.defaultSettings request

--- a/src/Api/Util.elm
+++ b/src/Api/Util.elm
@@ -14,11 +14,15 @@ infixl 0 :>
     Result.andThen
 
 
+{-| Insert accessToken into Http header
+-}
 withAccessToken : String -> Http.Request -> Http.Request
 withAccessToken accessToken =
     JsonApi.Extra.httpWithHeader "Authorization" ("Bearer " ++ accessToken)
 
 
+{-| Build a GET request with an accessToken
+-}
 requestGet : String -> String -> Http.Request
 requestGet accessToken url =
     withAccessToken accessToken
@@ -29,6 +33,8 @@ requestGet accessToken url =
         }
 
 
+{-| Build a POST request with an accessToken
+-}
 requestPost : String -> String -> String -> Http.Request
 requestPost accessToken url body =
     withAccessToken accessToken
@@ -39,6 +45,9 @@ requestPost accessToken url body =
         }
 
 
+{-| Send a Http request with default settings
+and decode the response from a JSON API document
+-}
 sendJsonApi :
     (JsonApi.Document -> Result String a)
     -> Http.Request

--- a/src/JsonApi/Extra.elm
+++ b/src/JsonApi/Extra.elm
@@ -1,0 +1,29 @@
+module JsonApi.Extra exposing (..)
+
+import Json.Decode as Decode
+import Task exposing (Task)
+import Http
+import JsonApi
+import JsonApi.Decode
+
+
+httpWithHeader : String -> String -> Http.Request -> Http.Request
+httpWithHeader field value request =
+    { request | headers = ( field, value ) :: request.headers }
+
+
+{-| Send a Http request and decode the response from a JSON API document
+-}
+httpSendJsonApi :
+    (JsonApi.Document -> Result String a)
+    -> Http.Settings
+    -> Http.Request
+    -> Task Http.Error a
+httpSendJsonApi assembleResponse settings request =
+    Http.send settings
+        (request
+            |> httpWithHeader "Content-Type" "application/vnd.api+json"
+            |> httpWithHeader "Accept" "application/vnd.api+json"
+        )
+        |> Http.fromJson
+            (Decode.customDecoder JsonApi.Decode.document assembleResponse)

--- a/src/JsonApi/Extra.elm
+++ b/src/JsonApi/Extra.elm
@@ -7,6 +7,8 @@ import JsonApi
 import JsonApi.Decode
 
 
+{-| Insert a header field into a Http request
+-}
 httpWithHeader : String -> String -> Http.Request -> Http.Request
 httpWithHeader field value request =
     { request | headers = ( field, value ) :: request.headers }

--- a/src/JsonApi/Extra.elm
+++ b/src/JsonApi/Extra.elm
@@ -9,23 +9,23 @@ import JsonApi.Decode
 
 {-| Insert a header field into a Http request
 -}
-httpWithHeader : String -> String -> Http.Request -> Http.Request
-httpWithHeader field value request =
+withHeader : String -> String -> Http.Request -> Http.Request
+withHeader field value request =
     { request | headers = ( field, value ) :: request.headers }
 
 
 {-| Send a Http request and decode the response from a JSON API document
 -}
-httpSendJsonApi :
+sendJsonApi :
     (JsonApi.Document -> Result String a)
     -> Http.Settings
     -> Http.Request
     -> Task Http.Error a
-httpSendJsonApi assembleResponse settings request =
+sendJsonApi assembleResponse settings request =
     Http.send settings
         (request
-            |> httpWithHeader "Content-Type" "application/vnd.api+json"
-            |> httpWithHeader "Accept" "application/vnd.api+json"
+            |> withHeader "Content-Type" "application/vnd.api+json"
+            |> withHeader "Accept" "application/vnd.api+json"
         )
         |> Http.fromJson
             (Decode.customDecoder JsonApi.Decode.document assembleResponse)

--- a/src/JsonApi/Extra.elm
+++ b/src/JsonApi/Extra.elm
@@ -1,6 +1,7 @@
 module JsonApi.Extra exposing (..)
 
 import Json.Decode as Decode
+import Json.Encode as Encode
 import Task exposing (Task)
 import Http
 import JsonApi
@@ -29,3 +30,16 @@ sendJsonApi assembleResponse settings request =
         )
         |> Http.fromJson
             (Decode.customDecoder JsonApi.Decode.document assembleResponse)
+
+
+encodeDocument : String -> Encode.Value -> String
+encodeDocument resourceType attributes =
+    Encode.object
+        [ ( "data"
+          , Encode.object
+                [ ( "type", Encode.string resourceType )
+                , ( "attributes", attributes )
+                ]
+          )
+        ]
+        |> Encode.encode 0

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -127,7 +127,7 @@ type alias Model =
     , accessToken : String
     , error : Maybe String
     , me : Me
-    , form : Form () ProposalInput
+    , form : Form () NewProposal
     , mdl : Material.Model
     , proposals : Dict String Proposal
     }
@@ -221,9 +221,9 @@ update msg model =
             Material.update msg' model
 
 
-validate : Validation () ProposalInput
+validate : Validation () NewProposal
 validate =
-    form2 ProposalInput
+    form2 NewProposal
         (get "title" string)
         (get "body" string)
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -26,6 +26,7 @@ import Navigation
 import UrlParser exposing ((</>))
 import Hop
 import Hop.Types exposing (Config, Address, Query)
+import Types exposing (..)
 import Api
 
 
@@ -125,7 +126,7 @@ type alias Model =
     , address : Address
     , accessToken : String
     , error : Maybe String
-    , me : Api.Me
+    , me : Me
     , form : Form () ProposalAttr
     , mdl : Material.Model
     , proposals : Dict String Proposal
@@ -144,30 +145,6 @@ initialModel accessToken route address =
     , mdl = Material.model
     , proposals = Dict.empty
     , participants = Dict.empty
-    }
-
-
-type alias ProposalAttr =
-    { title : String
-    , body : String
-    }
-
-
-type alias Proposal =
-    { id : String
-    , author : String
-    , attr : ProposalAttr
-    }
-
-
-type alias ParticipantAttr =
-    { name : String
-    }
-
-
-type alias Participant =
-    { id : String
-    , attr : ParticipantAttr
     }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -86,7 +86,7 @@ urlUpdate ( route, address ) model =
                 case Dict.get id model.proposals of
                     Nothing ->
                         ( model1
-                        , Api.getProposalCmd id model.accessToken ApiMsg
+                        , Api.getProposal id model.accessToken ApiMsg
                         )
 
                     Just _ ->
@@ -104,7 +104,7 @@ checkForAuthCode address =
     in
         case authCode of
             Just code ->
-                Api.authenticateCmd code ApiMsg
+                Api.authenticate code ApiMsg
 
             Nothing ->
                 Cmd.none
@@ -172,7 +172,7 @@ update msg model =
                     ( { model | accessToken = accessToken }
                     , Cmd.batch
                         [ storeAccessToken accessToken
-                        , Api.getMeCmd accessToken ApiMsg
+                        , Api.getMe accessToken ApiMsg
                         ]
                     )
 
@@ -209,7 +209,7 @@ update msg model =
         FormMsg formMsg ->
             case ( formMsg, Form.getOutput model.form ) of
                 ( Form.Submit, Just proposalInput ) ->
-                    model ! [ Api.createProposalCmd proposalInput model.accessToken ApiMsg ]
+                    model ! [ Api.createProposal proposalInput model.accessToken ApiMsg ]
 
                 _ ->
                     ( { model | form = Form.update formMsg model.form }, Cmd.none )

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -6,7 +6,7 @@ type alias Me =
     }
 
 
-type alias ProposalInput =
+type alias NewProposal =
     { title : String
     , body : String
     }

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -6,7 +6,7 @@ type alias Me =
     }
 
 
-type alias ProposalAttr =
+type alias ProposalInput =
     { title : String
     , body : String
     }
@@ -14,34 +14,13 @@ type alias ProposalAttr =
 
 type alias Proposal =
     { id : String
-    , author : String
-    , attr : ProposalAttr
-    }
-
-
-type alias ParticipantAttr =
-    { name : String
+    , title : String
+    , body : String
+    , author : Participant
     }
 
 
 type alias Participant =
     { id : String
-    , attr : ParticipantAttr
+    , name : String
     }
-
-
-
-{-
-   type alias Proposal =
-       { id : String
-       , title : String
-       , body : String
-       , author : Participant
-       }
-
-
-   type alias Participant =
-       { id : String
-       , name : String
-       }
--}

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,0 +1,47 @@
+module Types exposing (..)
+
+
+type alias Me =
+    { name : String
+    }
+
+
+type alias ProposalAttr =
+    { title : String
+    , body : String
+    }
+
+
+type alias Proposal =
+    { id : String
+    , author : String
+    , attr : ProposalAttr
+    }
+
+
+type alias ParticipantAttr =
+    { name : String
+    }
+
+
+type alias Participant =
+    { id : String
+    , attr : ParticipantAttr
+    }
+
+
+
+{-
+   type alias Proposal =
+       { id : String
+       , title : String
+       , body : String
+       , author : Participant
+       }
+
+
+   type alias Participant =
+       { id : String
+       , name : String
+       }
+-}


### PR DESCRIPTION
- Common types moved to new module `Types`
- `Proposal` and `Participant` includes its attributes unnested
- `Proposal` includes author as `Participant` field (no join over `id` necessary)
- No need to model a participants mapping
- `ProposalInput` specifies those fields that are needed for creating a new proposal

Overview of types representing API resources:

```elm
type alias Proposal =
    { id : String
    , title : String
    , body : String
    , author : Participant
    }

type alias Participant =
    { id : String
    , name : String
    }
```

Not implemented: Lookup for participant's name from [included](http://jsonapi.org/format/#document-compound-documents) resource data.
So, `proposal.author.name` gets only a dummy value for now.

We will probably switch to [elm-jsonapi](https://github.com/noahzgordon/elm-jsonapi) later (#31), which will handle this lookup out of the box. So we refrain from implementing this somewhat laborious functionality for now.
