### PR TITLE
Fix dev server settings to serve /index.html on all routes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
 
   devServer: {
     inline: true,
+    historyApiFallback: true,
     stats: 'errors-only',
   },
 


### PR DESCRIPTION
As we use html5 routes without a hash sign, webpack-dev-server needs a configuration to serve /index.html even if it is requested to get another URL. See [webpack-dev-server documentation](http://webpack.github.io/docs/webpack-dev-server.html#the-historyapifallback-option).

Server behaviour was correct until we switched to webpack-dev-server in PR #36. I missed to configure the server appropriately. Most visible when a fresh login with facebook results in `Cannot GET /facebook_redirect?code=...`