### PR TITLE
Supporting a proposal

### DIFF
--- a/src/Api.elm
+++ b/src/Api.elm
@@ -160,7 +160,9 @@ decodeParticipantAttributes =
 
 encodeProposalInput : NewProposal -> String
 encodeProposalInput proposalInput =
-    JsonApi.Extra.encodeDocument "proposal"
+    JsonApi.Extra.encodeDocument
+        "proposal"
+        Nothing
         [ ( "title", Encode.string proposalInput.title )
         , ( "body", Encode.string proposalInput.body )
         ]
@@ -169,7 +171,9 @@ encodeProposalInput proposalInput =
 
 encodeSupportProposal : String -> String
 encodeSupportProposal id =
-    JsonApi.Extra.encodeDocument "support"
+    JsonApi.Extra.encodeDocument
+        "support"
+        Nothing
         []
         [ ( "proposal"
           , JsonApi.Extra.resourceLinkage <|

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -120,7 +120,7 @@ assembleProposalList document =
 assembleProposalFromResource : JsonApi.Resource -> Result String Proposal
 assembleProposalFromResource proposalResource =
     JsonApi.Resources.attributes decodeProposalAttributes proposalResource
-        :> \( title, body ) ->
+        :> \( title, body, supportCount ) ->
             JsonApi.Resources.relatedResource "author" proposalResource
                 :> \participantResource ->
                     JsonApi.Resources.attributes decodeParticipantAttributes participantResource
@@ -133,14 +133,16 @@ assembleProposalFromResource proposalResource =
                                     { id = JsonApi.Resources.id participantResource
                                     , name = name
                                     }
+                                , supportCount = supportCount
                                 }
 
 
-decodeProposalAttributes : Decoder ( String, String )
+decodeProposalAttributes : Decoder ( String, String, Int )
 decodeProposalAttributes =
-    Decode.object2 (,)
+    Decode.object3 (,,)
         (Decode.at [ "title" ] Decode.string)
         (Decode.at [ "body" ] Decode.string)
+        (Decode.at [ "support-count" ] Decode.int)
 
 
 decodeParticipantAttributes : Decoder String

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -160,30 +160,22 @@ decodeParticipantAttributes =
 
 encodeProposalInput : NewProposal -> String
 encodeProposalInput proposalInput =
-    JsonApi.Extra.encodeDocument "proposal" <|
-        Encode.object
-            [ ( "title", Encode.string proposalInput.title )
-            , ( "body", Encode.string proposalInput.body )
-            ]
+    JsonApi.Extra.encodeDocument "proposal"
+        [ ( "title", Encode.string proposalInput.title )
+        , ( "body", Encode.string proposalInput.body )
+        ]
+        []
 
 
 encodeSupportProposal : String -> String
 encodeSupportProposal id =
-    """
-{
-  "data": {
-    "type": "support",
-    "relationships": {
-      "proposal": {
-        "data": {
-          "id": "31",
-          "type": "proposal"
-        }
-      }
-    }
-  }
-}
-    """
+    JsonApi.Extra.encodeDocument "support"
+        []
+        [ ( "proposal"
+          , JsonApi.Extra.resourceLinkage <|
+                Just ( "proposal", id )
+          )
+        ]
 
 
 

--- a/src/JsonApi/Extra.elm
+++ b/src/JsonApi/Extra.elm
@@ -47,16 +47,30 @@ type ResourceLinkage
     | ResourceLinkageMany (List ( String, String ))
 
 
+{-| Build a to-one resource linkage by type and id
+of the related resource
+-}
 resourceLinkage : Maybe ( String, String ) -> ResourceLinkage
 resourceLinkage =
     ResourceLinkageOne
 
 
+{-| Build a to-many resource linkage from a list of type-id-pairs
+-}
 resourceLinkageCollection : List ( String, String ) -> ResourceLinkage
 resourceLinkageCollection =
     ResourceLinkageMany
 
 
+{-| Encode a resource object for request to create or update a resource.
+
+The resource is specified by:
+- a resource type
+- a list of attributes
+- a list of relationships
+
+Returns JSON as a string suitable for a POST or PATCH request.
+-}
 encodeDocument :
     String
     -> List ( String, Encode.Value )

--- a/src/JsonApi/Extra.elm
+++ b/src/JsonApi/Extra.elm
@@ -66,6 +66,7 @@ resourceLinkageCollection =
 
 The resource is specified by:
 - a resource type
+- an optional client-generated id
 - a list of attributes
 - a list of relationships
 
@@ -73,14 +74,21 @@ Returns JSON as a string suitable for a POST or PATCH request.
 -}
 encodeDocument :
     String
+    -> Maybe String
     -> List ( String, Encode.Value )
     -> List ( String, ResourceLinkage )
     -> String
-encodeDocument resourceType attributes relationships =
+encodeDocument resourceType optionalId attributes relationships =
     let
         encodedType : ( String, Encode.Value )
         encodedType =
             ( "type", Encode.string resourceType )
+
+        encodedId : Maybe ( String, Encode.Value )
+        encodedId =
+            Maybe.map
+                (\id -> ( "id", Encode.string id ))
+                optionalId
 
         encodedAttributes : Maybe ( String, Encode.Value )
         encodedAttributes =
@@ -120,7 +128,9 @@ encodeDocument resourceType attributes relationships =
             [ ( "data"
               , Encode.object <|
                     List.filterMap identity <|
+                        -- skips unused elements
                         [ Just encodedType
+                        , encodedId
                         , encodedAttributes
                         , encodedRelationships
                         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3,7 +3,7 @@ port module Main exposing (main)
 import Html exposing (..)
 import Html.App as App
 import Html.Events exposing (..)
-import Html.Attributes exposing (style, href, class)
+import Html.Attributes exposing (style, href, class, disabled)
 import Material
 import Material.Scheme
 import Material.Button as Button
@@ -455,13 +455,18 @@ viewProposal model id =
                 , div [] [ text "Author: ", text proposal.author.name ]
                 , div [] [ text "Body: ", text proposal.body ]
                 , div [] [ text "Support Count: ", text <| toString proposal.supportCount ]
-                , button [ onClick <| SupportProposal id (not proposal.supportedByMe) ]
-                    [ text <|
-                        if proposal.supportedByMe then
-                            "Unsupport this proposal (unimplemented)"
-                        else
-                            "Support this proposal"
-                    ]
+                , if proposal.authoredByMe then
+                    button [ disabled True ]
+                        [ text "Authored by me, automatically supported"
+                        ]
+                  else
+                    button [ onClick <| SupportProposal id (not proposal.supportedByMe) ]
+                        [ text <|
+                            if proposal.supportedByMe then
+                                "Unsupport this proposal (unimplemented)"
+                            else
+                                "Support this proposal"
+                        ]
                 ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -136,7 +136,6 @@ type alias Model =
     , form : Form () NewProposal
     , mdl : Material.Model
     , proposals : Dict String Proposal
-    , supportedByMe : Set String
     }
 
 
@@ -150,7 +149,6 @@ initialModel accessToken route address =
     , form = Form.initial [] validate
     , mdl = Material.model
     , proposals = Dict.empty
-    , supportedByMe = Set.empty
     }
 
 
@@ -164,7 +162,7 @@ type Msg
     | FormMsg Form.Msg
     | NoOp
     | Mdl (Material.Msg Msg)
-    | SupportProposal String
+    | SupportProposal String Bool
 
 
 addProposal : Proposal -> Model -> Model
@@ -207,7 +205,7 @@ update msg model =
                     ( { model | error = Just <| toString httpError }, Cmd.none )
 
                 Api.ProposalSupported id ->
-                    ( { model | supportedByMe = Set.insert id model.supportedByMe }
+                    ( model
                     , Navigation.newUrl <|
                         Hop.output hopConfig { path = [ "proposals", id ], query = Dict.empty }
                     )
@@ -252,9 +250,9 @@ update msg model =
         Mdl msg' ->
             Material.update msg' model
 
-        SupportProposal id ->
+        SupportProposal id newState ->
             ( model
-            , Api.supportProposal id model.accessToken ApiMsg
+            , Api.supportProposal id newState model.accessToken ApiMsg
             )
 
 
@@ -436,10 +434,10 @@ viewProposal model id =
                 , div [] [ text "Author: ", text proposal.author.name ]
                 , div [] [ text "Body: ", text proposal.body ]
                 , div [] [ text "Support Count: ", text <| toString proposal.supportCount ]
-                , button [ onClick <| SupportProposal id ]
+                , button [ onClick <| SupportProposal id (not proposal.supportedByMe) ]
                     [ text <|
-                        if Set.member id model.supportedByMe then
-                            "Unsupport this proposal"
+                        if proposal.supportedByMe then
+                            "Unsupport this proposal (unimplemented)"
                         else
                             "Support this proposal"
                     ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -414,9 +414,10 @@ viewProposal model id =
 
         Just proposal ->
             div []
-                [ div [] [ text "Titel: ", text proposal.title ]
+                [ div [] [ text "Title: ", text proposal.title ]
                 , div [] [ text "Author: ", text proposal.author.name ]
                 , div [] [ text "Body: ", text proposal.body ]
+                , div [] [ text "Support Count: ", text <| toString proposal.supportCount ]
                 ]
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -175,6 +175,28 @@ addProposalList proposalList model =
     List.foldl addProposal model proposalList
 
 
+updateProposalSupport : Support -> Model -> Model
+updateProposalSupport support model =
+    let
+        newProposals =
+            Dict.update support.proposal
+                (Maybe.map
+                    (\proposal ->
+                        { proposal
+                            | supportCount = support.supportCount
+                            , supportedByMe = support.supportedByMe
+                        }
+                    )
+                )
+                model.proposals
+    in
+        { model | proposals = newProposals }
+
+
+
+-- { model | proposals = Dict.insert proposal.id proposal model.proposals }
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -204,10 +226,9 @@ update msg model =
                 Api.ProposalCreationFailed httpError ->
                     ( { model | error = Just <| toString httpError }, Cmd.none )
 
-                Api.ProposalSupported id ->
-                    ( model
-                    , Navigation.newUrl <|
-                        Hop.output hopConfig { path = [ "proposals", id ], query = Dict.empty }
+                Api.ProposalSupported support ->
+                    ( model |> updateProposalSupport support
+                    , Cmd.none
                     )
 
                 Api.SupportProposalFailed httpError ->

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -31,3 +31,11 @@ type alias Participant =
     { id : String
     , name : String
     }
+
+
+type alias Support =
+    { id : String
+    , proposal : String
+    , supportCount : Int
+    , supportedByMe : Bool
+    }

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -17,6 +17,7 @@ type alias Proposal =
     , title : String
     , body : String
     , author : Participant
+    , supportCount : Int
     }
 
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -17,7 +17,9 @@ type alias Proposal =
     , title : String
     , body : String
     , author : Participant
+    , authoredByMe : Bool
     , supportCount : Int
+    , supportedByMe : Bool
     }
 
 


### PR DESCRIPTION
```
As a participant
I want to support proposals by other participants
```

When viewing a proposal not his own, a participant sees a "Support this" button. When clicking on it, the button should change in some way to signify it's "on" somehow. Or maybe the proposal itself could have a visual cue that it's supported? 
- [ ] Define UX
